### PR TITLE
@import refs use destination file as relative root

### DIFF
--- a/tasks/less_imports.js
+++ b/tasks/less_imports.js
@@ -8,8 +8,9 @@
 
 'use strict';
 
-module.exports = function(grunt) {
+var path = require('path');
 
+module.exports = function(grunt) {
 	// Please see the Grunt documentation for more information regarding task
 	// creation: http://gruntjs.com/creating-tasks
 
@@ -19,7 +20,10 @@ module.exports = function(grunt) {
 			// Merge task-specific and/or target-specific options with these defaults.
 			options = this.options({
 				inlineCSS: true
-			})
+			}),
+			dest = this.files[0].dest,
+			relRoot = path.dirname(dest),
+			resolved
 		;
 
 		// Iterate over all specified file groups.
@@ -37,15 +41,16 @@ module.exports = function(grunt) {
 						css += grunt.file.read(filepath) + '\n\n';
 					}
 					else {
-						grunt.log.debug(filepath.green + ' @import created'.magenta);
-						lessImports += '@import "' + filepath + '";\n';
+						resolved = path.relative(relRoot, filepath);
+						grunt.log.debug(resolved.green + ' @import created'.magenta);
+						lessImports += '@import "' + resolved + '";\n';
 					}
 				}
 			});
 		});
 
 		// Write the destination file.
-		grunt.file.write(this.files[0].dest, css + lessImports);
+		grunt.file.write(dest, css + lessImports);
 		grunt.log.writeln('File "' + this.files[0].dest.cyan + '" created.');
 	});
 

--- a/test/expected/default/imports.less
+++ b/test/expected/default/imports.less
@@ -1,3 +1,3 @@
 body { color: black; }
 
-@import "test/fixtures/styles.less";
+@import "../../test/fixtures/styles.less";

--- a/test/expected/inline_css_false/imports.less
+++ b/test/expected/inline_css_false/imports.less
@@ -1,2 +1,2 @@
-@import "test/fixtures/styles.css";
-@import "test/fixtures/styles.less";
+@import "../../test/fixtures/styles.css";
+@import "../../test/fixtures/styles.less";


### PR DESCRIPTION
@import refs are current generated relative to the project root. This PR makes it so @import refs use the destination file destination as the relative root.
