### PR TITLE
Use slashes as URI delimiter in LESS imports.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
   "scripts": {
     "test": "grunt test"
   },
+  "dependencies": {
+    "slash": "^1.0.0"
+  },
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-contrib-clean": "^0.6.0",


### PR DESCRIPTION
Fixes #16.